### PR TITLE
Add a public timestamp() function to the Key Node

### DIFF
--- a/src/key_node.rs
+++ b/src/key_node.rs
@@ -334,6 +334,14 @@ impl KeyNodeItemRange {
         Some(Ok(key_node_item_range))
     }
 
+    fn timestamp<'h, B>(&self, hive: &'h Hive<B>) -> Result<u64>
+    where
+        B: SplitByteSlice,
+    {
+        let header = self.header(hive);
+        Ok(header.timestamp.get())
+    }
+
     fn validate_signature<B>(&self, hive: &Hive<B>) -> Result<()>
     where
         B: SplitByteSlice,
@@ -458,6 +466,12 @@ where
             hive: self.hive,
             item_range,
         }))
+    }
+
+    /// Returns the timestamp of this Key Node in the FILETIME format.
+    /// i.e. the number of 100-nanosecond intervals since January 1, 1601 (UTC).
+    pub fn timestamp(&self) -> Result<u64> {
+        self.item_range.timestamp(self.hive)
     }
 
     /// Finds a single value by name.


### PR DESCRIPTION
Hello,

I am using nt-hive for forensic analysis, and I need to extract the timestamp of the key nodes.
I created a public function for this purpose and I hope you will accept to include it in the main repository. 

Many thanks for this great library,
Best regards,
Adrien